### PR TITLE
Disable built-in RTC for ARMADA 390.

### DIFF
--- a/arch/arm/boot/dts/armada-390.dtsi
+++ b/arch/arm/boot/dts/armada-390.dtsi
@@ -55,6 +55,11 @@
 				compatible = "marvell,mv88f6920-pinctrl";
 				reg = <0x18000 0x20>;
 			};
+
+			rtc@a3800 {
+				/* RTC is supported on ARMADA 395 and 398 only */
+				status = "disabled";
+			};
 		};
 	};
 };


### PR DESCRIPTION
The build-in RTC is supported on 395 and 398, but not 390.